### PR TITLE
Feature/remove GitHub changelog

### DIFF
--- a/lib/u2i/ci_utils/rake_tasks/all.rb
+++ b/lib/u2i/ci_utils/rake_tasks/all.rb
@@ -1,3 +1,2 @@
 load 'u2i/ci_utils/rake_tasks/rspec.rake'
 load 'u2i/ci_utils/rake_tasks/rubocop.rake'
-load 'u2i/ci_utils/rake_tasks/changelog.rake'

--- a/lib/u2i/ci_utils/rake_tasks/changelog.rake
+++ b/lib/u2i/ci_utils/rake_tasks/changelog.rake
@@ -1,6 +1,0 @@
-require 'github_changelog_generator/task'
-
-namespace :ci do
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  end
-end

--- a/u2i-ci_utils.gemspec
+++ b/u2i-ci_utils.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ci_reporter'
   spec.add_dependency 'ci_reporter_rspec'
-  spec.add_dependency 'github_changelog_generator'
 end


### PR DESCRIPTION
I've removed github changelog generator. It's not used by anyone anywhere so it's pointless to have it here. 

@mknapik please check
