### PR TITLE
Bump pronto dependencies to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [3.2.1] - 2017-07-04
 
 ### Added
 
 ### Changed
 - Drop support for Ruby 1.9
+- Bump simplecov dependency to '~> 0.14.1'
 
 ## [3.2.0] - 2016-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Bump pronto and its plugins to the latest version
+- Use the latest version of path_expander instead of git fork
 
 ## [3.2.1] - 2017-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.2.1] - 2017-07-04
+## [3.3.0] - 2018-03-13
 
-### Added
+### Changed
+- Bump pronto and its plugins to the latest version
+
+## [3.2.1] - 2017-07-04
 
 ### Changed
 - Drop support for Ruby 1.9

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-# Remove once seattlerb/path_expander#2 is resolved
-gem 'path_expander', '~> 1.0.1', git: 'https://github.com/mknapik/path_expander.git', branch: '6734999'
+gem 'path_expander', '~> 1.0.2'
 gem 'rubocop-rspec', '~> 1.4.0'
 
 gemspec

--- a/u2i-ci_utils.gemspec
+++ b/u2i-ci_utils.gemspec
@@ -36,11 +36,11 @@ Gem::Specification.new do |spec|
   if RUBY_PLATFORM == 'java'
     spec.platform = 'java'
   else
-    spec.add_dependency 'pronto', '~> 0.9'
-    spec.add_dependency 'pronto-rubocop', '~> 0.9'
-    spec.add_dependency 'pronto-brakeman', '~> 0.9'
-    spec.add_dependency 'pronto-flay', '~> 0.9'
-    spec.add_dependency 'pronto-reek', '~> 0.9'
-    spec.add_dependency 'pronto-fasterer', '~> 0.9'
+    spec.add_dependency 'pronto', '~> 0.9.5'
+    spec.add_dependency 'pronto-rubocop', '~> 0.9.0'
+    spec.add_dependency 'pronto-brakeman', '~> 0.9.1'
+    spec.add_dependency 'pronto-flay', '~> 0.9.0'
+    spec.add_dependency 'pronto-reek', '~> 0.9.0'
+    spec.add_dependency 'pronto-fasterer', '~> 0.9.0'
   end
 end


### PR DESCRIPTION
Required to use the recent rubocop